### PR TITLE
Fix dependencies issues shapely/MVT and free localost from osmose.openstreetmap.fr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ web/po/vue.pot
 
 web_api/session/
 web_api/public/
-web_api/static/
+web_api/static/node_modules
 
 web/static/.webassets-cache/
 web/static/gen/

--- a/osmose.py
+++ b/osmose.py
@@ -11,20 +11,17 @@ from modules.utils import LangsNegociation
 from web_api import app as web_api
 
 app = FastAPI()
+assets = FastAPI()
 
-origins = [
-    "https://osmose.openstreetmap.fr",
-    "http://localhost",
-    "http://localhost:8080",
-    "http://localhost:20009",
-    "http://127.0.0.1",
-    "http://127.0.0.1:8080",
-    "http://127.0.0.1:20009"
-]
-
-app.add_middleware(
+assets.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=[
+        "https://osmose.openstreetmap.fr",
+        "http://localhost",
+        "http://localhost:8080",
+        "http://127.0.0.1",
+        "http://127.0.0.1:8080",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -49,6 +46,8 @@ for lang in utils.allowed_languages:
     app.mount("/" + lang, web_api.app)
 
 
+app.mount('/assets', assets)
+
 @app.get("/")
 @app.get("/map")
 @app.get("/map/")
@@ -62,7 +61,7 @@ def index(request: Request, langs: LangsNegociation = Depends(langs.langs)):
     return responses.RedirectResponse(url=path)
 
 
-@app.get("/assets/sprites.css")
+@assets.get("/sprites.css")
 def sprites_css():
     file_path = "web_api/public/assets/sprites.css"
     if os.path.isfile(file_path):
@@ -71,17 +70,17 @@ def sprites_css():
         raise HTTPException(status_code=404)
 
 
-@app.get("/assets/sprite.png")
+@assets.get("/sprite.png")
 def sprite_png():
     return Response(open("web_api/public/assets/sprite.png", "rb").read())
 
 
-@app.get("/assets/marker-gl-sprite.json")
+@assets.get("/marker-gl-sprite.json")
 def sprite_png():
     return Response(open("web_api/public/assets/marker-gl-sprite.json", "rb").read())
 
 
-@app.get("/assets/marker-gl-sprite.png")
+@assets.get("/marker-gl-sprite.png")
 def sprite_png():
     return Response(open("web_api/public/assets/marker-gl-sprite.png", "rb").read())
 

--- a/osmose.py
+++ b/osmose.py
@@ -1,6 +1,7 @@
 import os
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, responses
+from fastapi.middleware.cors import CORSMiddleware
 
 from api import app as api
 from control import app as control
@@ -11,6 +12,23 @@ from web_api import app as web_api
 
 app = FastAPI()
 
+origins = [
+    "https://osmose.openstreetmap.fr",
+    "http://localhost",
+    "http://localhost:8080",
+    "http://localhost:20009",
+    "http://127.0.0.1",
+    "http://127.0.0.1:8080",
+    "http://127.0.0.1:20009"
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.on_event("startup")
 async def startup():
@@ -56,6 +74,16 @@ def sprites_css():
 @app.get("/assets/sprite.png")
 def sprite_png():
     return Response(open("web_api/public/assets/sprite.png", "rb").read())
+
+
+@app.get("/assets/marker-gl-sprite.json")
+def sprite_png():
+    return Response(open("web_api/public/assets/marker-gl-sprite.json", "rb").read())
+
+
+@app.get("/assets/marker-gl-sprite.png")
+def sprite_png():
+    return Response(open("web_api/public/assets/marker-gl-sprite.png", "rb").read())
 
 
 @app.get("/images/markers/{filename:path}.png")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ matplotlib >= 1.1
 requests >= 2.0
 polib
 protobuf < 4 # 4.x binary not yet compatible with system package, deps of mapbox-vector-tile
+shapely < 2.1.0 # cascaded_union function removal, deps of mapbox-vector-tile
 mapbox-vector-tile
 pyclipper
 fastapi

--- a/web/static/map/layers.ts
+++ b/web/static/map/layers.ts
@@ -1,5 +1,7 @@
 import { SourceSpecification } from 'maplibre-gl'
 
+declare var API_URL: string;
+
 function tileSource(url, options?): SourceSpecification {
   return {
     type: 'raster',
@@ -97,8 +99,6 @@ export const mapOverlay = {
   markers: 'Osmose Issues',
   heatmap: 'Osmose Issues Heatmap',
 }
-
-const API_URL = 'https://osmose.openstreetmap.fr'
 
 export const glStyle = {
   version: 8,

--- a/web/types/index.d.ts
+++ b/web/types/index.d.ts
@@ -1,5 +1,0 @@
-declare global {
-    var API_URL: string
-}
-
-export { }

--- a/web_api/static/webpack.config.js
+++ b/web_api/static/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env, argv) => {
         },
         plugins: [
             new SpritezeroWebpackPlugin({
-                source: '../web_api/static/images/**/*.svg',
+                source: 'images/**/*.svg',
                 output: 'marker-gl-',
             })
         ],


### PR DESCRIPTION
Fix two issues preventing local map to run when testing or dev:
- Python's mapbox-vector-tile depends on shapely 2.0.4 but >=2.1.0 already removed deprecated methods, so limiting required version prevent breaking changes
- Web map was still linked to osmose.openstreetmap.fr to get maplibre's sprites. It is proposed to expose them directly in uvicorn app and allow localhost:8080 to query localhost:20009 to get them

I recommend to give it a try on public infrastructure. I didn't know how marker-gl-sprite is exposed today as there is no mention in uvicorn app nor in apache-site files.
This PR intends to establish a common way to serve those files both in dev and in prod.